### PR TITLE
28 testtest blittestblittest blit m broken locally

### DIFF
--- a/src/Blit.cpp
+++ b/src/Blit.cpp
@@ -82,8 +82,10 @@ extern "C" {
         }
     }
 
-    float test_blit_m(float f) {
-        return blit_m(f);
+    void test_blit_m(float * m, float * f, unsigned int samples) {
+        for (unsigned int i = 0; i < samples; i++) {
+            m[i] = blit_m(f[i]);
+        }
     }
 }
 

--- a/src/Synth.cpp
+++ b/src/Synth.cpp
@@ -82,11 +82,13 @@ extern "C" {
         //              r: release time (in samples)
         //              modDepth: modulation depth
         //              modFreq: modulation frequency
+        //              gen: type of generator
         //              presses: number of presses
         //              pressNs: times at which to press
-        //              notes: MIDI notes to press at each time step
+        //              pressNotes: MIDI notes to press at each time step
         //              releases: number of releases
         //              releaseNs: times at which to release
+        //              releaseNotes: MIDI notes to release at each time step
         //              n: number of samples to iterate over.
         //                  if n is not a multiple of block_size, the last fraction of a block won't be filled in
         //              envOut: generated envelope

--- a/test/test_blit.py
+++ b/test/test_blit.py
@@ -16,27 +16,25 @@ class BlitInterface:
     ''' Interface for BLIT functions '''
     testlib = ctypes.CDLL('test.so')
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
         self.testlib.test_blit_m.argtypes = [float_pointer, float_pointer, ctypes.c_int]
         self.testlib.test_blit.argtypes = [float_pointer, ctypes.c_float, ctypes.c_int]
+        self.testlib.test_bp_blit.argtypes = [float_pointer, ctypes.c_float, ctypes.c_int]
 
     def run_blit(self, freq: float, num_samples: int) -> np.ndarray:
         ''' wrapper around blit test function, generates its own co/sines '''
         out = np.zeros(num_samples, dtype=np.single)
         p_out = out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
-        self.testlib.test_blit(p_out, ctypes.c_float(freq/sampling_frequency), len(out))
+        self.testlib.test_blit(p_out, freq/sampling_frequency, len(out))
         return out
 
     def run_bp_blit(self, freq: float, num_samples: int) -> np.ndarray:
         ''' wrapper around bpblit test function, generates its own co/sines '''
         out = np.zeros(num_samples, dtype=np.single)
         p_out = out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
-        self.testlib.test_bp_blit(p_out, ctypes.c_float(freq/sampling_frequency), len(out))
+        self.testlib.test_bp_blit(p_out, freq/sampling_frequency, len(out))
         return out
 
     def run_blit_m(self, freqs: list) -> list:
@@ -49,7 +47,7 @@ class BlitInterface:
         return out
 
 
-class TestBlit(unittest.TestCase, BlitInterface):
+class TestBlit(BlitInterface, unittest.TestCase):
     ''' Test class for BLIT '''
     debug = False
 
@@ -134,7 +132,8 @@ class TestBlit(unittest.TestCase, BlitInterface):
 def main():
     ''' For Debugging/Testing '''
     blit_test = TestBlit()
-    blit_test.debug = True
+    blit_test.setUp()
+    # blit_test.debug = True
     blit_test.test_blit_m()
     blit_test.test_blit_freq()
 

--- a/test/test_blit.py
+++ b/test/test_blit.py
@@ -16,6 +16,9 @@ class BlitInterface:
     ''' Interface for BLIT functions '''
     testlib = ctypes.CDLL('test.so')
 
+    def __init__(self):
+        self.setUp()
+
     def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
@@ -131,7 +134,6 @@ class TestBlit(unittest.TestCase, BlitInterface):
 def main():
     ''' For Debugging/Testing '''
     blit_test = TestBlit()
-    blit_test.setUp()
     blit_test.debug = True
     blit_test.test_blit_m()
     blit_test.test_blit_freq()

--- a/test/test_envelope.py
+++ b/test/test_envelope.py
@@ -20,6 +20,9 @@ class EnvelopeInterface:
     testlib = ctypes.CDLL('test.so')
 
     def __init__(self):
+        self.setUp()
+
+    def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
         uint_pointer = ctypes.POINTER(ctypes.c_uint)

--- a/test/test_envelope.py
+++ b/test/test_envelope.py
@@ -19,9 +19,6 @@ class EnvelopeInterface:
     release_seconds = 0
     testlib = ctypes.CDLL('test.so')
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
@@ -40,11 +37,11 @@ class EnvelopeInterface:
         out_p = out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
         presses_p = np.array(presses, dtype=np.uintc).ctypes.data_as(p_uint)
         releases_p = np.array(releases, dtype=np.uintc).ctypes.data_as(p_uint)
-        self.testlib.test_envelope(ctypes.c_float(self.attack_seconds), ctypes.c_float(self.decay_seconds),
-                                    ctypes.c_float(self.sustain), ctypes.c_float(self.release_seconds),
-                                    ctypes.c_uint(len(presses)), presses_p,
-                                    ctypes.c_uint(len(releases)), releases_p,
-                                    ctypes.c_uint(len(out)), out_p)
+        self.testlib.test_envelope(self.attack_seconds, self.decay_seconds,
+                                    self.sustain, self.release_seconds,
+                                    len(presses), presses_p,
+                                    len(releases), releases_p,
+                                    len(out), out_p)
         return out
 
     def set_adsr(self, attack: float, decay: float, sustain: float, release: float):
@@ -66,7 +63,7 @@ class EnvelopeInterface:
         return a_grad, d_grad, r_grad
 
 
-class TestEnvelope(unittest.TestCase, EnvelopeInterface):
+class TestEnvelope(EnvelopeInterface, unittest.TestCase):
     ''' Test for envelope generator '''
     debug = False
 
@@ -245,7 +242,8 @@ class TestEnvelope(unittest.TestCase, EnvelopeInterface):
 def main():
     ''' For Debugging/Testing '''
     env_test = TestEnvelope()
-    env_test.debug = True
+    env_test.setUp()
+    # env_test.debug = True
     env_test.test_basic_envelope()
     env_test.test_double_press()
 

--- a/test/test_modulator.py
+++ b/test/test_modulator.py
@@ -12,6 +12,9 @@ class ModulatorInterface:
     testlib = ctypes.CDLL('test.so')
 
     def __init__(self):
+        self.setUp()
+
+    def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
         self.testlib.test_modulator.argtypes = [ctypes.c_float, ctypes.c_float,

--- a/test/test_modulator.py
+++ b/test/test_modulator.py
@@ -11,9 +11,6 @@ class ModulatorInterface:
     ''' ctypes wrapper around test shared object file'''
     testlib = ctypes.CDLL('test.so')
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
@@ -24,11 +21,11 @@ class ModulatorInterface:
         ''' Run the Modulator. Modulates a constant signal'''
         out = np.zeros(n_samples, dtype=np.single)
         out_p = out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
-        self.testlib.test_modulator(ctypes.c_float(freq/sampling_frequency),
-                                     ctypes.c_float(ratio), ctypes.c_int(n_samples), out_p)
+        self.testlib.test_modulator(freq/sampling_frequency,
+                                     ratio, n_samples, out_p)
         return out
 
-class TestModulator(unittest.TestCase, ModulatorInterface):
+class TestModulator(ModulatorInterface, unittest.TestCase):
     ''' test class for modulator'''
     debug = False
     tolerance = 0.01
@@ -75,6 +72,7 @@ class TestModulator(unittest.TestCase, ModulatorInterface):
 def main():
     ''' For debugging/plotting '''
     mod_test = TestModulator()
+    mod_test.setUp()
     mod_test.debug = True
     mod_test.test_model()
 

--- a/test/test_oscillator.py
+++ b/test/test_oscillator.py
@@ -16,6 +16,9 @@ class OscillatorInterface:
     testlib = ctypes.CDLL('test.so')
 
     def __init__(self):
+        self.setUp()
+
+    def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
         self.testlib.test_oscillator.argtypes = [ctypes.c_float, ctypes.c_int,

--- a/test/test_oscillator.py
+++ b/test/test_oscillator.py
@@ -15,9 +15,6 @@ class OscillatorInterface:
     freq = 0
     testlib = ctypes.CDLL('test.so')
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         float_pointer = ctypes.POINTER(ctypes.c_float)
@@ -30,7 +27,7 @@ class OscillatorInterface:
         cos_out_p = cos_out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
         sin_out = np.zeros(n_samples, dtype=np.single)
         sin_out_p = sin_out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
-        self.testlib.test_oscillator(ctypes.c_float(self.freq), ctypes.c_int(n_samples), cos_out_p, sin_out_p)
+        self.testlib.test_oscillator(self.freq, n_samples, cos_out_p, sin_out_p)
         return cos_out + 1j*sin_out
 
     def set_f(self, freq: float):
@@ -42,7 +39,7 @@ class OscillatorInterface:
         return int(2**math.ceil(math.log2((sampling_frequency/precision))))
 
 
-class TestOscillator(unittest.TestCase, OscillatorInterface):
+class TestOscillator(OscillatorInterface, unittest.TestCase):
     ''' Test Suite for Oscillator, checks frequency accuracy and amplitude accuracy/consistency.
         Uses an interface to the OscillatorInterface '''
     debug = False # controls whether plots will be made
@@ -107,7 +104,8 @@ class TestOscillator(unittest.TestCase, OscillatorInterface):
 def main():
     ''' For debugging/plotting '''
     osc_test = TestOscillator()
-    osc_test.debug = True
+    osc_test.setUp()
+    # osc_test.debug = True
     osc_test.test_sine_frequency()
     osc_test.test_sine_amplitude()
 

--- a/test/test_synth.py
+++ b/test/test_synth.py
@@ -15,9 +15,6 @@ class SynthInterface(VoiceInterface):
     mod_depth = 0
     mod_freq = 0
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         super().setUp()
@@ -26,14 +23,16 @@ class SynthInterface(VoiceInterface):
         uint8_pointer = ctypes.POINTER(ctypes.c_uint8)
         # a, d, s, r,
         # modDepth, modFreq,
+        # generator,
         # presses, pressNs, pressNotes,
-        # releases, releaseNs,
+        # releases, releaseNs, releaseNotes,
         # n, envOut
         self.testlib.test_synth.argtypes = [ctypes.c_float, ctypes.c_float,
                                                 ctypes.c_float, ctypes.c_float,
                                                 ctypes.c_float, ctypes.c_float,
+                                                ctypes.c_uint,
                                                 ctypes.c_uint, uint_pointer, uint8_pointer,
-                                                ctypes.c_uint, uint_pointer,
+                                                ctypes.c_uint, uint_pointer, uint8_pointer,
                                                 ctypes.c_uint, float_pointer]
         self.testlib.test_frequency_table.argtypes = [float_pointer]
 
@@ -47,13 +46,13 @@ class SynthInterface(VoiceInterface):
         p_notes_p = np.array(p_notes, dtype=np.uint8).ctypes.data_as(p_uint8)
         r_notes_p = np.array(r_notes, dtype=np.uint8).ctypes.data_as(p_uint8)
         releases_p = np.array(releases, dtype=np.uintc).ctypes.data_as(p_uint)
-        self.testlib.test_synth(ctypes.c_float(self.attack_seconds), ctypes.c_float(self.decay_seconds),
-                                    ctypes.c_float(self.sustain), ctypes.c_float(self.release_seconds),
-                                    ctypes.c_float(self.mod_depth), ctypes.c_float(self.mod_freq),
-                                    ctypes.c_uint(generators[self.generator]),
-                                    ctypes.c_uint(len(presses)), presses_p, p_notes_p,
-                                    ctypes.c_uint(len(releases)), releases_p, r_notes_p,
-                                    ctypes.c_uint(len(out)), out_p)
+        self.testlib.test_synth(self.attack_seconds, self.decay_seconds,
+                                    self.sustain, self.release_seconds,
+                                    self.mod_depth, self.mod_freq,
+                                    generators[self.generator],
+                                    len(presses), presses_p, p_notes_p,
+                                    len(releases), releases_p, r_notes_p,
+                                    len(out), out_p)
         return out
 
     def run_frequency_table(self):
@@ -64,7 +63,7 @@ class SynthInterface(VoiceInterface):
         return table
 
 
-class TestSynth(TestVoice, TestModulator, SynthInterface):
+class TestSynth(SynthInterface, TestVoice, TestModulator):
     ''' Test suite for synthesiser module'''
     note = 64
     test_notes = [13*n for n in range(9)] + [127]
@@ -158,11 +157,12 @@ class TestSynth(TestVoice, TestModulator, SynthInterface):
 def main():
     ''' For Debugging/Testing '''
     synth_test = TestSynth()
-    synth_test.debug = True
-    # synth_test.test_model()
-    # synth_test.test_envelope()
-    # synth_test.test_frequency()
-    # synth_test.test_frequency_table()
+    synth_test.setUp()
+    # synth_test.debug = True
+    synth_test.test_model()
+    synth_test.test_envelope()
+    synth_test.test_frequency()
+    synth_test.test_frequency_table()
     synth_test.play_notes()
 
 if __name__=='__main__':

--- a/test/test_synth.py
+++ b/test/test_synth.py
@@ -16,8 +16,11 @@ class SynthInterface(VoiceInterface):
     mod_freq = 0
 
     def __init__(self):
+        self.setUp()
+
+    def setUp(self):
         ''' Load in the test object file and define the function '''
-        super().__init__()
+        super().setUp()
         float_pointer = ctypes.POINTER(ctypes.c_float)
         uint_pointer = ctypes.POINTER(ctypes.c_uint)
         uint8_pointer = ctypes.POINTER(ctypes.c_uint8)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,9 +9,6 @@ import numpy as np
 class UtilsInterface:
     ''' ctypes wrapper around test shared object file'''
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         self.testlib = ctypes.CDLL('test.so')
@@ -22,22 +19,18 @@ class UtilsInterface:
     def run_db2mag(self, data: np.ndarray) -> None:
         ''' Run the Envelope Generator. Output is a float'''
         io_p = data.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
-        self.testlib.test_db2mag(ctypes.c_uint(len(data)), io_p)
+        self.testlib.test_db2mag(len(data), io_p)
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(UtilsInterface, unittest.TestCase,):
     ''' Tests for Utils'''
     debug = False
-
-    def setUp(self) -> None:
-        ''' Set up function, loads in the utils interface '''
-        self.implementation = UtilsInterface()
 
     def test_db2mag(self) -> None:
         ''' Tests db2mag function across a range of values '''
         data = np.linspace(-100, 100, 200, dtype=np.float32)
         ref = 10**(data/20)
-        self.implementation.run_db2mag(data)
+        self.run_db2mag(data)
         error = 100*(data-ref)/ref
         # within 0.0001%, arbitrary value
         self.assertAlmostEqual(np.max(np.abs(error)), 0, delta=0.0001)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,7 +8,11 @@ import numpy as np
 
 class UtilsInterface:
     ''' ctypes wrapper around test shared object file'''
+
     def __init__(self):
+        self.setUp()
+
+    def setUp(self):
         ''' Load in the test object file and define the function '''
         self.testlib = ctypes.CDLL('test.so')
         float_pointer = ctypes.POINTER(ctypes.c_float)

--- a/test/test_voice.py
+++ b/test/test_voice.py
@@ -23,8 +23,12 @@ class VoiceInterface(EnvelopeInterface, OscillatorInterface):
     generator = 'sine'
 
     def __init__(self):
+        self.setUp()
+
+    def setUp(self):
         ''' Load in the test object file and define the function '''
-        super().__init__()
+        EnvelopeInterface.setUp(self)
+        OscillatorInterface.setUp(self)
         float_pointer = ctypes.POINTER(ctypes.c_float)
         uint_pointer = ctypes.POINTER(ctypes.c_uint)
         # a, d, s, r, f, presses, pressNs, releases, releaseNs, n_samples, envOut

--- a/test/test_voice.py
+++ b/test/test_voice.py
@@ -22,9 +22,6 @@ class VoiceInterface(EnvelopeInterface, OscillatorInterface):
     ''' Interface class for voice module '''
     generator = 'sine'
 
-    def __init__(self):
-        self.setUp()
-
     def setUp(self):
         ''' Load in the test object file and define the function '''
         EnvelopeInterface.setUp(self)
@@ -34,7 +31,7 @@ class VoiceInterface(EnvelopeInterface, OscillatorInterface):
         # a, d, s, r, f, presses, pressNs, releases, releaseNs, n_samples, envOut
         self.testlib.test_voice.argtypes = [ctypes.c_float, ctypes.c_float,
                                                ctypes.c_float, ctypes.c_float,
-                                               ctypes.c_float,
+                                               ctypes.c_float, ctypes.c_uint,
                                                ctypes.c_uint, uint_pointer,
                                                ctypes.c_uint, uint_pointer,
                                                ctypes.c_uint, float_pointer]
@@ -46,17 +43,17 @@ class VoiceInterface(EnvelopeInterface, OscillatorInterface):
         out_p = out.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
         presses_p = np.array(presses, dtype=np.uintc).ctypes.data_as(p_uint)
         releases_p = np.array(releases, dtype=np.uintc).ctypes.data_as(p_uint)
-        self.testlib.test_voice(ctypes.c_float(self.attack_seconds), ctypes.c_float(self.decay_seconds),
-                                    ctypes.c_float(self.sustain), ctypes.c_float(self.release_seconds),
-                                    ctypes.c_float(self.freq), ctypes.c_uint(generators[self.generator]),
-                                    ctypes.c_uint(len(presses)), presses_p,
-                                    ctypes.c_uint(len(releases)), releases_p,
-                                    ctypes.c_uint(len(out)), out_p)
+        self.testlib.test_voice(self.attack_seconds, self.decay_seconds,
+                                    self.sustain, self.release_seconds,
+                                    self.freq, generators[self.generator],
+                                    len(presses), presses_p,
+                                    len(releases), releases_p,
+                                    len(out), out_p)
         return out
 
 
 
-class TestVoice(unittest.TestCase, VoiceInterface):
+class TestVoice(VoiceInterface, unittest.TestCase):
     ''' Test implementations for voice module'''
     freq = 1000
     f_expected = 1000
@@ -154,7 +151,8 @@ class TestVoice(unittest.TestCase, VoiceInterface):
 def main():
     ''' For Debugging/Testing '''
     voice_test = TestVoice()
-    voice_test.debug = True
+    voice_test.setUp()
+    # voice_test.debug = True
     voice_test.test_envelope()
     voice_test.test_frequency()
 


### PR DESCRIPTION
Modified blit m value test function to work by passing an array of floats rather than from return values - suspect that there was some ctypes gremlin causing the return value to be misinterpreted
also tidied up use of setUp functions to make ctypes argument type specifications actually work